### PR TITLE
fix(getReleaseRefs): support issues without body

### DIFF
--- a/src/utils/getReleaseRefs.ts
+++ b/src/utils/getReleaseRefs.ts
@@ -50,7 +50,7 @@ export async function getReleaseRefs(
   for (const issue of issuesFromCommits) {
     // Ignore regular issues as they may not close/fix other issues
     // by reference (at least on GitHub).
-    if (!issue.pull_request) {
+    if (!issue.pull_request || !issue.body) {
       continue
     }
 
@@ -63,8 +63,8 @@ export async function getReleaseRefs(
 
 export interface IssueOrPullRequest {
   html_url: string
-  pull_request: any
-  body: string
+  pull_request: Record<string, string> | null
+  body: string | null
 }
 
 async function fetchIssue(id: string): Promise<IssueOrPullRequest> {

--- a/src/utils/github/createGitHubRelease.ts
+++ b/src/utils/github/createGitHubRelease.ts
@@ -15,7 +15,11 @@ export async function createGitHubRelease(
   const { repo } = context
 
   log.info(
-    format('creating a new release at "%s/%s"...', repo.owner, repo.name),
+    format(
+      'creating a new GitHub release at "%s/%s"...',
+      repo.owner,
+      repo.name,
+    ),
   )
 
   const response = await fetch(


### PR DESCRIPTION
Issues and pull requests may not have `body`. Release must account for that when parsing child references.

- Originated from [this CI job](https://github.com/mswjs/cookies/runs/6387443353?check_suite_focus=true#step:6:79)