### PR TITLE
fix(getReleaseNotes): use format as "YYYY-MM-DD"

### DIFF
--- a/src/commands/__test__/notes.test.ts
+++ b/src/commands/__test__/notes.test.ts
@@ -115,7 +115,7 @@ it('creates a GitHub release for a past release', async () => {
 
   // Must generate correct release notes.
   expect(log.info).toHaveBeenCalledWith(`generated release notes:
-## v0.2.0 (07/04/2005)
+## v0.2.0 (2005-04-07)
 
 ### Features
 

--- a/src/utils/__test__/formatDate.test.ts
+++ b/src/utils/__test__/formatDate.test.ts
@@ -1,0 +1,6 @@
+import { formatDate } from '../formatDate'
+
+it('formats a given date using "YYYY-MM-DD" mask', () => {
+  expect(formatDate(new Date(2020, 0, 5))).toBe('2020-01-05')
+  expect(formatDate(new Date(2020, 11, 15))).toBe('2020-12-15')
+})

--- a/src/utils/__test__/getReleaseNotes.test.ts
+++ b/src/utils/__test__/getReleaseNotes.test.ts
@@ -108,7 +108,7 @@ describe(toMarkdown, () => {
     const markdown = toMarkdown(context, notes)
 
     expect(markdown).toEqual(`\
-## v0.1.0 (20/04/2022)
+## v0.1.0 (2022-04-20)
 
 ### Features
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,7 @@
+export function formatDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}

--- a/src/utils/getReleaseNotes.ts
+++ b/src/utils/getReleaseNotes.ts
@@ -1,4 +1,5 @@
 import type { ReleaseContext } from './createContext'
+import { formatDate } from './formatDate'
 import type { ParsedCommitWithHash } from './git/parseCommits'
 
 export type ReleaseNotes = Map<string, Set<ParsedCommitWithHash>>
@@ -33,15 +34,8 @@ export function toMarkdown(
   notes: ReleaseNotes,
 ): string {
   const markdown: string[] = []
+  const releaseDate = formatDate(context.nextRelease.publishedAt)
 
-  const releaseDate = context.nextRelease.publishedAt.toLocaleDateString(
-    'en-GB',
-    {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    },
-  )
   markdown.push(`## ${context.nextRelease.tag} (${releaseDate})`)
 
   const sections: Record<'feat' | 'fix', string[]> = {


### PR DESCRIPTION
The `en_US` locale may be inapplicable for certain countries. I suggest this tool uses a neutral `YYYY-MM-DD` date format that cannot be confused with anything else. 