### PR TITLE
fix: ignore invalid release tags

### DIFF
--- a/src/utils/git/getLatestRelease.ts
+++ b/src/utils/git/getLatestRelease.ts
@@ -1,6 +1,10 @@
 import * as semver from 'semver'
 import { getTag, TagPointer } from './getTag'
 
+function isValid(tag: string) {
+  return semver.valid(tag);
+}
+
 export function byReleaseVersion(left: string, right: string): number {
   return semver.rcompare(left, right)
 }
@@ -8,7 +12,7 @@ export function byReleaseVersion(left: string, right: string): number {
 export async function getLatestRelease(
   tags: string[],
 ): Promise<TagPointer | undefined> {
-  const allTags = tags.sort(byReleaseVersion)
+  const allTags = tags.filter(isValid).sort(byReleaseVersion)
   const [latestTag] = allTags
 
   if (!latestTag) {

--- a/src/utils/git/getLatestRelease.ts
+++ b/src/utils/git/getLatestRelease.ts
@@ -12,7 +12,9 @@ export function byReleaseVersion(left: string, right: string): number {
 export async function getLatestRelease(
   tags: string[],
 ): Promise<TagPointer | undefined> {
-  const allTags = tags.filter(isValid).sort(byReleaseVersion)
+  const allTags = tags.filter((tag) => {
+    return sermver.isValid(tag)
+  }).sort(byReleaseVersion)
   const [latestTag] = allTags
 
   if (!latestTag) {

--- a/src/utils/git/getLatestRelease.ts
+++ b/src/utils/git/getLatestRelease.ts
@@ -1,10 +1,6 @@
 import * as semver from 'semver'
 import { getTag, TagPointer } from './getTag'
 
-function isValid(tag: string) {
-  return semver.valid(tag);
-}
-
 export function byReleaseVersion(left: string, right: string): number {
   return semver.rcompare(left, right)
 }
@@ -13,7 +9,7 @@ export async function getLatestRelease(
   tags: string[],
 ): Promise<TagPointer | undefined> {
   const allTags = tags.filter((tag) => {
-    return sermver.isValid(tag)
+    return semver.valid(tag)
   }).sort(byReleaseVersion)
   const [latestTag] = allTags
 


### PR DESCRIPTION
this filters out non-valid semrel releases when looking for the latest release to add compatibility with legacy repos with non-semrel tags