### PR TITLE
fix(createReleaseTag): only push the tag being created right now

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -312,7 +312,7 @@ export class Publish extends Command<Argv> {
 
     const tagResult = await until(async () => {
       const tag = await createTag(nextTag)
-      await execAsync('git push --tags')
+      await execAsync(`git push origin ${tag}`)
       return tag
     })
 


### PR DESCRIPTION
this change only pushes the release tag to the origin instead of all local tags. Some might not be relevant to the release or may already exist remotely, causing the publish command to fail.