### PR TITLE
chore: build cli before release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm build
+
       - name: Release
         run: pnpm release
         env:


### PR DESCRIPTION
Fixes release job failures due to missing build of the library. 