### PR TITLE
fix(publish): improve stdout

### DIFF
--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -455,7 +455,7 @@ it('streams the release script stderr to the main process', async () => {
     }),
     'stream-stderr.js': `
 console.error('something')
-setTimeout(() => console.error('went wrong'), 100)
+setTimeout(() => process.stderr.write('went wrong'), 100)
 setTimeout(() => process.exit(0), 150)
       `,
   })


### PR DESCRIPTION
There are [scenarios](https://github.com/mswjs/interceptors/actions/runs/6026954852/job/16351054611) when Release notifies about the exited publish script but prints nothing into stdout. I believe that happens due to the nature of `execAsync` and how it accumulates stdout/stderr. 

I'm opting into using `exec` directly here, relying on the deferred promise of that execution. `exec` should pipe the stdio into the parent's process, printing the data as it comes in. 