### PR TITLE
feat: support "prerelease" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ This tool expects a configuration file at `release.config.json`. The configurati
      * @example "pnpm publish --no-git-checks"
      */
     use: string
+
+    /**
+     * Treat major version bumps as minor.
+     * This prevents publishing a package that is in a
+     * pre-release phase (< 1.0).
+     */
+    prerelease?: boolean
   }>
   use: string
 }

--- a/release.config.json
+++ b/release.config.json
@@ -2,7 +2,8 @@
   "profiles": [
     {
       "name": "latest",
-      "use": "pnpm publish --no-git-checks"
+      "use": "pnpm publish --no-git-checks",
+      "prerelease": true
     }
   ]
 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -144,7 +144,9 @@ export class Publish extends Command<PublishArgv> {
     }
 
     // Get the next release type and version number.
-    const nextReleaseType = getNextReleaseType(commits)
+    const nextReleaseType = getNextReleaseType(commits, {
+      prerelease: this.profile.prerelease,
+    })
     if (!nextReleaseType) {
       this.log.warn('committed changes do not bump version, skipping...')
       return

--- a/src/utils/__test__/getNextReleaseType.test.ts
+++ b/src/utils/__test__/getNextReleaseType.test.ts
@@ -116,3 +116,43 @@ it('returns null when no commits bump the version', async () => {
     ),
   ).toBe(null)
 })
+
+it('returns "minor" for a breaking change if "prerelease" option is set', async () => {
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'feat(parseUrl): support relative urls',
+          body: 'BREAKING CHANGE: This is a breaking change.',
+        }),
+      ]),
+      { prerelease: true },
+    ),
+  ).toBe('minor')
+})
+
+it('returns "minor" for a minor change if "prerelease" option is set', async () => {
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'feat: minor change',
+        }),
+      ]),
+      { prerelease: true },
+    ),
+  ).toBe('minor')
+})
+
+it('returns "patch" for a patch change if "prerelease" option is set', async () => {
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'fix: some fixes',
+        }),
+      ]),
+      { prerelease: true },
+    ),
+  ).toBe('patch')
+})

--- a/src/utils/getConfig.ts
+++ b/src/utils/getConfig.ts
@@ -14,6 +14,12 @@ export interface ReleaseProfile {
    * @example pnpm publish --no-git-checks
    */
   use: string
+
+  /**
+   * Indicate a pre-release version.
+   * Treat breaking changes as minor release versions.
+   */
+  prerelease?: boolean
 }
 
 export function getConfig(): Config {

--- a/src/utils/getNextReleaseType.ts
+++ b/src/utils/getNextReleaseType.ts
@@ -1,6 +1,10 @@
 import * as semver from 'semver'
 import { ParsedCommitWithHash } from './git/parseCommits'
 
+interface GetNextReleaseTypeOptions {
+  prerelease?: boolean
+}
+
 /**
  * Determine if the given commit describes a breaking change.
  * @note For now, this only analyzes the "BREAKING CHANGE" comment
@@ -12,12 +16,13 @@ export function isBreakingChange(commit: ParsedCommitWithHash): boolean {
 
 export function getNextReleaseType(
   commits: ParsedCommitWithHash[],
+  options?: GetNextReleaseTypeOptions,
 ): semver.ReleaseType | null {
   const ranges: ['minor' | null, 'patch' | null] = [null, null]
 
   for (const commit of commits) {
     if (isBreakingChange(commit)) {
-      return 'major'
+      return options?.prerelease ? 'minor' : 'major'
     }
 
     // Respect the parsed "type" from the "conventional-commits-parser".

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -21,7 +21,7 @@ export async function initGit(
   /**
    * @note Switch to the `main` branch to support olders versions of Git.
    */
-  await fs.exec('git switch -c main')
+  await fs.exec('git switch -c main').catch(() => void 0)
 
   await fs.exec('git push -u origin main')
 }


### PR DESCRIPTION
This helps lock down the version range so a package never gets published as a major version. This would have fixed the issue where MSW had been mistakingly published as 1.0 by the pull request description including the words "breaking change". 