### PR TITLE
fix(publish): log publish process stderr as warnings

### DIFF
--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -500,9 +500,9 @@ setTimeout(() => process.exit(0), 150)
 
   await publish.run()
 
-  // Must log the release script stdout.
-  expect(log.error).toHaveBeenCalledWith('something\n')
-  expect(log.error).toHaveBeenCalledWith('went wrong\n')
+  // Must log the release script stderr.
+  expect(log.warn).toHaveBeenCalledWith('something\n')
+  expect(log.warn).toHaveBeenCalledWith('went wrong\n')
 
   // Must report a successful release.
   // As long as the publish script doesn't exit, it is successful.

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -274,7 +274,7 @@ export class Publish extends Command<PublishArgv> {
       this.log.info(Buffer.from(chunk).toString('utf8'))
     })
     releaseScriptPromise.io.stderr?.on('data', (chunk) => {
-      this.log.error(Buffer.from(chunk).toString('utf8'))
+      this.log.warn(Buffer.from(chunk).toString('utf8'))
     })
 
     await releaseScriptPromise.catch((error) => {


### PR DESCRIPTION
It is not uncommon for tools to print warnings into `stderr` (NPM does it). This correctly forwards those errors as a warning in logger so the consumer aren't freaking out when the release script suddenly prints a bunch of `ERROR:`. 