### PR TITLE
fix(publish): pipe release script stdio to the parent process

### DIFF
--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -76,8 +76,8 @@ it('publishes the next minor version', async () => {
   expect(log.info).toHaveBeenCalledWith('release type "minor": 0.0.0 -> 0.1.0')
 
   // The release script is provided with the environmental variables.
-  expect(log.info).toHaveBeenCalledWith(
-    expect.stringContaining('release script input: 0.1.0\n'),
+  expect(process.stdout.write).toHaveBeenCalledWith(
+    'release script input: 0.1.0\n',
   )
   expect(log.info).toHaveBeenCalledWith(
     expect.stringContaining('bumped version in package.json to: 0.1.0'),
@@ -163,8 +163,8 @@ it('releases a new version after an existing version', async () => {
   expect(log.info).toHaveBeenCalledWith('release type "minor": 1.2.3 -> 1.3.0')
 
   // The release script is provided with the environmental variables.
-  expect(log.info).toHaveBeenCalledWith(
-    expect.stringContaining('release script input: 1.3.0\n'),
+  expect(process.stdout.write).toHaveBeenCalledWith(
+    'release script input: 1.3.0\n',
   )
   expect(log.info).toHaveBeenCalledWith(
     expect.stringContaining('bumped version in package.json to: 1.3.0'),
@@ -441,8 +441,8 @@ setTimeout(() => process.exit(0), 150)
   await publish.run()
 
   // Must log the release script stdout.
-  expect(log.info).toHaveBeenCalledWith('hello\n')
-  expect(log.info).toHaveBeenCalledWith('world\n')
+  expect(process.stdout.write).toHaveBeenCalledWith('hello\n')
+  expect(process.stdout.write).toHaveBeenCalledWith('world\n')
 
   // Must report a successful release.
   expect(log.info).toHaveBeenCalledWith('release type "minor": 0.0.0 -> 0.1.0')
@@ -501,8 +501,8 @@ setTimeout(() => process.exit(0), 150)
   await publish.run()
 
   // Must log the release script stderr.
-  expect(log.warn).toHaveBeenCalledWith('something\n')
-  expect(log.warn).toHaveBeenCalledWith('went wrong\n')
+  expect(process.stderr.write).toHaveBeenCalledWith('something\n')
+  expect(process.stderr.write).toHaveBeenCalledWith('went wrong\n')
 
   // Must report a successful release.
   // As long as the publish script doesn't exit, it is successful.
@@ -620,8 +620,8 @@ it('treats breaking changes as minor versions when "prerelease" is set to true',
 
   // Must expose the correct environment variable
   // to the publish script.
-  expect(log.info).toHaveBeenCalledWith(
-    expect.stringContaining('release script input: 0.2.0\n'),
+  expect(process.stdout.write).toHaveBeenCalledWith(
+    'release script input: 0.2.0\n',
   )
 
   // Must bump the "version" in package.json.
@@ -692,8 +692,8 @@ it('treats minor bumps as minor versions when "prerelease" is set to true', asyn
 
   // Must expose the correct environment variable
   // to the publish script.
-  expect(log.info).toHaveBeenCalledWith(
-    expect.stringContaining('release script input: 0.1.0\n'),
+  expect(process.stdout.write).toHaveBeenCalledWith(
+    'release script input: 0.1.0\n',
   )
 
   // Must bump the "version" in package.json.

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -270,12 +270,8 @@ export class Publish extends Command<PublishArgv> {
     })
 
     // Forward the publish script's stdio to the logger.
-    releaseScriptPromise.io.stdout?.on('data', (chunk) => {
-      this.log.info(Buffer.from(chunk).toString('utf8'))
-    })
-    releaseScriptPromise.io.stderr?.on('data', (chunk) => {
-      this.log.warn(Buffer.from(chunk).toString('utf8'))
-    })
+    releaseScriptPromise.io.stdout?.pipe(process.stdout)
+    releaseScriptPromise.io.stderr?.pipe(process.stderr)
 
     await releaseScriptPromise.catch((error) => {
       this.log.error(error)

--- a/test/env.ts
+++ b/test/env.ts
@@ -62,6 +62,8 @@ export function testEnvironment(
     api,
     async setup() {
       jest.spyOn(process, 'exit')
+      jest.spyOn(process.stdout, 'write').mockImplementation()
+      jest.spyOn(process.stderr, 'write').mockImplementation()
       jest.spyOn(log, 'info').mockImplementation()
       jest.spyOn(log, 'warn').mockImplementation()
       jest.spyOn(log, 'error').mockImplementation()


### PR DESCRIPTION
Using the logger to print the release script's stdio may result in broken formatting:

<img width="638" alt="Screenshot 2023-09-02 at 15 51 19" src="https://github.com/ossjs/release/assets/14984911/f0508ada-91dd-49b9-8e8f-f7f2fad638f7">

Instead, this forwards the release script's stdio to the parent process. 