### PR TITLE
test(getNextReleaseType): add tests for false breaking changes

### DIFF
--- a/src/utils/__test__/getNextReleaseType.test.ts
+++ b/src/utils/__test__/getNextReleaseType.test.ts
@@ -60,6 +60,72 @@ it('returns "major" for commits with a "!" type appendix', async () => {
   ).toBe('major')
 })
 
+it('does not return "major" for a commit that includes "breaking change" generic text', async () => {
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'fix: some breaking change',
+        }),
+      ]),
+    ),
+  ).toBe('patch')
+
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'feat(scope): some breaking change',
+        }),
+      ]),
+    ),
+  ).toBe('minor')
+
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'feat(scope): abc',
+          body: 'this is good because it is not a breaking change',
+        }),
+      ]),
+    ),
+  ).toBe('minor')
+
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'docs: abc',
+          body: 'should this be a BREAKING CHANGE?',
+        }),
+      ]),
+    ),
+  ).toBe(null)
+})
+
+it('does not return "major" for a commit that includes "!" in its message', async () => {
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'fix: adds "!" as supported character',
+        }),
+      ]),
+    ),
+  ).toBe('patch')
+
+  expect(
+    getNextReleaseType(
+      await parseCommits([
+        mockCommit({
+          subject: 'feat: adds "!" as supported character',
+        }),
+      ]),
+    ),
+  ).toBe('minor')
+})
+
 it('returns "minor" for "feat" commits', async () => {
   expect(
     getNextReleaseType(

--- a/src/utils/getNextReleaseType.ts
+++ b/src/utils/getNextReleaseType.ts
@@ -46,13 +46,5 @@ export function getNextReleaseType(
     }
   }
 
-  /**
-   * @fixme Commit messages can also append "!" to the scope
-   * to indicate that the commit is a breaking change.
-   * @see https://www.conventionalcommits.org/en/v1.0.0/#summary
-   *
-   * Unfortunately, "conventional-commits-parser" does not support that.
-   */
-
   return ranges[0] || ranges[1]
 }


### PR DESCRIPTION
This library has produced a number of false breaking changes in the past:

- https://github.com/ossjs/release/commit/0caf7abf74ce195e4bc1990311976910f9d7e21a, which triggered a major version bump while it shouldn't).
- https://github.com/mswjs/headers-polyfill/commit/dd0b62489786d0f9e44d36d570bebed8169512b9, where it should've triggered a major bump but didn't (admittedly, my mistake; should be `BREAKING CHANGE:` with the semicolon).

This PR improves this behavior. 

It would be great to have a manual approval on any potential breaking change release from the developer. It seems that GitHub Actions don't support manual approvals amidst workflows. That's a shame. 

There are some alternatives, like https://github.com/marketplace/actions/manual-workflow-approval, but they introduce significantly different release workflow than I'd prefer (no PRs/issues/etc). 