### PR TITLE
fix: do not mark github release as latest if higher version exists

### DIFF
--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -35,6 +35,7 @@ it('publishes the next minor version', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -116,6 +117,7 @@ it('releases a new version after an existing version', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -216,6 +218,7 @@ it('comments on relevant github issues', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -402,6 +405,7 @@ it('streams the release script stdout to the main process', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -462,6 +466,7 @@ it('streams the release script stderr to the main process', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -527,6 +532,7 @@ it('only pushes the newly created release tag to the remote', async () => {
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -574,6 +580,7 @@ it('treats breaking changes as minor versions when "prerelease" is set to true',
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )
@@ -650,6 +657,7 @@ it('treats minor bumps as minor versions when "prerelease" is set to true', asyn
         return res(
           ctx.status(201),
           ctx.json({
+            tag_name: 'v1.0.0',
             html_url: '/releases/1',
           }),
         )

--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -22,6 +22,13 @@ afterAll(async () => {
   await cleanup()
 })
 
+const githubLatestReleaseHandler = rest.get<never, never, GitHubRelease>(
+  `https://api.github.com/repos/:owner/:name/releases/latest`,
+  (req, res, ctx) => {
+    return res(ctx.status(404))
+  },
+)
+
 it('publishes the next minor version', async () => {
   const repo = await createRepository('version-next-minor')
 
@@ -29,6 +36,7 @@ it('publishes the next minor version', async () => {
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -111,6 +119,7 @@ it('releases a new version after an existing version', async () => {
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -212,6 +221,7 @@ it('comments on relevant github issues', async () => {
         }),
       )
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -291,6 +301,7 @@ it('supports dry-run mode', async () => {
 
   api.use(
     graphql.query('GetCommitAuthors', getReleaseContributorsResolver),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       createGitHubReleaseResolver,
@@ -399,6 +410,7 @@ it('streams the release script stdout to the main process', async () => {
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -460,6 +472,7 @@ it('streams the release script stderr to the main process', async () => {
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -526,6 +539,7 @@ it('only pushes the newly created release tag to the remote', async () => {
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -574,6 +588,7 @@ it('treats breaking changes as minor versions when "prerelease" is set to true',
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {
@@ -651,6 +666,7 @@ it('treats minor bumps as minor versions when "prerelease" is set to true', asyn
     graphql.query('GetCommitAuthors', (req, res, ctx) => {
       return res(ctx.data({}))
     }),
+    githubLatestReleaseHandler,
     rest.post<never, never, GitHubRelease>(
       'https://api.github.com/repos/:owner/:repo/releases',
       (req, res, ctx) => {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -104,7 +104,13 @@ export class Publish extends Command<PublishArgv> {
       ),
     )
 
-    // Get the latest release.
+    /**
+     * Get the latest release.
+     * @note This refers to the latest release tag at the current
+     * state of the branch. Since Release doesn't do branch analysis,
+     * this doesn't guarantee the latest release in general
+     * (consider backport releases where you checkout an old SHA).
+     */
     const tags = await getTags()
     const latestRelease = await getLatestRelease(tags)
 

--- a/src/utils/github/__test__/createGitHubRelease.test.ts
+++ b/src/utils/github/__test__/createGitHubRelease.test.ts
@@ -1,0 +1,78 @@
+import { rest } from 'msw'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { testEnvironment } from '../../../../test/env'
+import { mockRepo } from '../../../../test/fixtures'
+import type { GitHubRelease } from '../getGitHubRelease'
+import { createGitHubRelease } from '../createGitHubRelease'
+
+const { setup, reset, cleanup, api } = testEnvironment({
+  fileSystemPath: 'create-github-release',
+})
+
+beforeAll(async () => {
+  await setup()
+})
+
+afterEach(async () => {
+  await reset()
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+it('marks the release as non-latest if there is a higher version released on GitHub', async () => {
+  const repo = mockRepo()
+  const requestBodyPromise = new DeferredPromise()
+  api.use(
+    rest.get<never, never, GitHubRelease>(
+      `https://api.github.com/repos/:owner/:name/releases/latest`,
+      (req, res, ctx) => {
+        return res(
+          // Set the latest GitHub release as v2.0.0.
+          ctx.json({
+            tag_name: 'v2.0.0',
+            html_url: '/v2.0.0',
+          }),
+        )
+      },
+    ),
+    rest.post<never, never, GitHubRelease>(
+      `https://api.github.com/repos/:owner/:name/releases`,
+      (req, res, ctx) => {
+        requestBodyPromise.resolve(req.json())
+        return res(
+          ctx.status(201),
+          ctx.json({
+            tag_name: 'v1.1.1',
+            html_url: '/v1.1.1',
+          }),
+        )
+      },
+    ),
+  )
+
+  // Try to release a backport version for v1.0.0.
+  const notes = '# Release notes'
+  const githubRelease = await createGitHubRelease(
+    {
+      repo,
+      nextRelease: {
+        version: '1.1.1',
+        tag: 'v1.1.1',
+        publishedAt: new Date(),
+      },
+    },
+    notes,
+  )
+  expect(githubRelease).toHaveProperty('html_url', '/v1.1.1')
+
+  const requestBody = await requestBodyPromise
+  expect(requestBody).toEqual({
+    tag_name: 'v1.1.1',
+    name: 'v1.1.1',
+    body: notes,
+    // Must set "false" as the value of the "make_latest" property.
+    make_latest: 'false',
+  })
+})

--- a/src/utils/github/__test__/getCommitAuthors.test.ts
+++ b/src/utils/github/__test__/getCommitAuthors.test.ts
@@ -1,9 +1,9 @@
+import { graphql } from 'msw'
 import { getCommitAuthors } from '../getCommitAuthors'
 import { log } from '../../../logger'
 import { mockCommit } from '../../../../test/fixtures'
 import { parseCommits } from '../../git/parseCommits'
 import { testEnvironment } from '../../../../test/env'
-import { graphql } from 'msw'
 
 const { setup, reset, cleanup, api } = testEnvironment({
   fileSystemPath: 'get-commit-authors',

--- a/src/utils/github/createGitHubRelease.ts
+++ b/src/utils/github/createGitHubRelease.ts
@@ -29,7 +29,13 @@ export async function createGitHubRelease(
   // latest release on GitHub. For that, fetch whichever latest
   // release exists on GitHub and see if its version is larger
   // than the version we are releasing right now.
-  const latestGitHubRelease = await getGitHubRelease('latest')
+  const latestGitHubRelease = await getGitHubRelease('latest').catch(
+    (error) => {
+      log.error(`Failed to fetch the latest GitHub release:`, error)
+      // We aren't interested in the GET endpoint errors in this context.
+      return undefined
+    },
+  )
   const shouldMarkAsLatest = latestGitHubRelease
     ? lt(latestGitHubRelease.tag_name || '0.0.0', context.nextRelease.tag)
     : // Undefined is fine, it means GitHub will use its default

--- a/src/utils/github/getGitHubRelease.ts
+++ b/src/utils/github/getGitHubRelease.ts
@@ -3,16 +3,19 @@ import fetch from 'node-fetch'
 import { getInfo } from '../git/getInfo'
 
 export interface GitHubRelease {
+  tag_name: string
   html_url: string
 }
 
 export async function getGitHubRelease(
-  tag: string,
+  tag: string | ('latest' & {}),
 ): Promise<GitHubRelease | undefined> {
   const repo = await getInfo()
 
   const response = await fetch(
-    `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/tags/${tag}`,
+    tag === 'latest'
+      ? `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/latest`
+      : `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/tags/${tag}`,
     {
       headers: {
         Accept: 'application/json',

--- a/test/env.ts
+++ b/test/env.ts
@@ -16,7 +16,9 @@ export const api = setupServer(
 )
 
 beforeAll(() => {
-  api.listen()
+  api.listen({
+    onUnhandledRequest: 'error',
+  })
 })
 
 afterEach(() => {


### PR DESCRIPTION
- Implements https://github.com/ossjs/release/discussions/68

This allows using Release for backport releases. It will generate the GitHub release notes as usual for backport releases, which is nice, but won't mark them as `latest`. 