### PR TITLE
fix: add json schema for release config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "node": ">=20.0.0"
   },
   "files": [
-    "bin"
+    "./bin",
+    "./src",
+    "./schema.json"
   ],
   "scripts": {
     "dev": "tsdown -w",

--- a/release.config.json
+++ b/release.config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./schema.json",
   "profiles": [
     {
       "name": "latest",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["profiles"],
+  "properties": {
+    "profiles": {
+      "type": "array",
+      "description": "The list of release targets.",
+      "items": {
+        "type": "object",
+        "required": ["name", "use"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The tag of this release.",
+            "minLength": 1
+          },
+          "use": {
+            "type": "string",
+            "description": "Command to run to perform the release itself.",
+            "minLength": 1
+          },
+          "prerelease": {
+            "type": "boolean",
+            "description": "Publish the package in a pre-release mode. Breaking changes in this mode produce minor version bumps instead of the major ones."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The users can now have IDE validation of the release configs by including the published schema:

```json
{
  "$schema": "./node_modules/@ossjs/release/schema.json",
  "profiles": [...]
}
```