### PR TITLE
feat: lint the releasing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "node-git-server": "^1.0.0-beta.30",
     "portfinder": "^1.0.28",
     "prettier": "^3.6.2",
-    "publint": "^0.3.13",
     "tsdown": "^0.15.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
@@ -61,6 +60,7 @@
     "outvariant": "^1.4.3",
     "pino": "^7.10.0",
     "pino-pretty": "^7.6.1",
+    "publint": "^0.3.13",
     "rc": "^1.2.8",
     "registry-auth-token": "^5.1.0",
     "semver": "^7.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       pino-pretty:
         specifier: ^7.6.1
         version: 7.6.1
+      publint:
+        specifier: ^0.3.13
+        version: 0.3.13
       rc:
         specifier: ^1.2.8
         version: 1.2.8
@@ -84,9 +87,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      publint:
-        specifier: ^0.3.13
-        version: 0.3.13
       tsdown:
         specifier: ^0.15.5
         version: 0.15.5(publint@0.3.13)(typescript@5.9.2)

--- a/src/commands/__test__/publish.test.ts
+++ b/src/commands/__test__/publish.test.ts
@@ -420,6 +420,7 @@ it('streams the release script stdout to the main process', async () => {
   await repo.fs.create({
     'package.json': JSON.stringify({
       name: 'publish-stream',
+      version: '0.0.0',
     }),
     'stream-stdout.js': `
 console.log('hello')

--- a/src/utils/__test__/create-release-comment.test.ts
+++ b/src/utils/__test__/create-release-comment.test.ts
@@ -25,6 +25,7 @@ it('creates a release comment for the "latest" profile', async () => {
   await repo.fs.create({
     'package.json': JSON.stringify({
       name: 'my-package',
+      version: '0.0.0',
     }),
   })
 
@@ -64,6 +65,7 @@ it('respects custom release profiles in the release comment', async () => {
   await repo.fs.create({
     'package.json': JSON.stringify({
       name: 'my-package',
+      version: '0.0.0',
     }),
   })
 

--- a/src/utils/lint-package.ts
+++ b/src/utils/lint-package.ts
@@ -1,0 +1,29 @@
+import { invariant } from 'outvariant'
+import { publint } from 'publint'
+import { formatMessage } from 'publint/utils'
+import { log } from '#/src/logger.js'
+import { execAsync } from './exec-async.js'
+
+export async function lintPackage(): Promise<void> {
+  const pkgDir = execAsync.contextOptions.cwd?.toString() || process.cwd()
+  const { messages, pkg } = await publint({
+    pkgDir,
+  })
+
+  let isValid = true
+
+  for (const message of messages) {
+    const logLevel = message.type === 'error' ? 'error' : 'warn'
+    log[logLevel](formatMessage(message, pkg))
+
+    if (message.type === 'error' || message.type === 'warning') {
+      isValid = false
+    }
+  }
+
+  invariant(
+    isValid,
+    'Failed to lint the package at "%s": the package contains issues that can potentially produce a broken release. Please resolve the issues above and retry the release.',
+    pkgDir,
+  )
+}

--- a/src/utils/read-package-json.ts
+++ b/src/utils/read-package-json.ts
@@ -4,7 +4,7 @@ import { execAsync } from '#/src/utils/exec-async.js'
 
 export function readPackageJson(): Record<string, any> {
   const packageJsonPath = path.resolve(
-    execAsync.contextOptions.cwd!.toString(),
+    execAsync.contextOptions.cwd?.toString() || process.cwd(),
     'package.json',
   )
 


### PR DESCRIPTION
- Closes #49

Adds a `lintPackage()` step that uses the JavaScript API of `publint` to make sure broken packages are never released. Hurray! 