### PR TITLE
chore: do not demand npm token anymore

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -25,7 +25,7 @@ import {
 } from '#/src/utils/git/parse-commits.js'
 import { createComment } from '#/src/utils/github/create-comment.js'
 import { createReleaseComment } from '#/src/utils/create-release-comment.js'
-import { demandGitHubToken, demandNpmToken } from '#/src/utils/env.js'
+import { demandGitHubToken } from '#/src/utils/env.js'
 import { Notes } from '#/src/commands/notes.js'
 import { type ReleaseProfile } from '#/src/utils/get-config.js'
 import { lintPackage } from '../utils/lint-package.js'
@@ -81,11 +81,6 @@ export class Publish extends Command<PublishArgv> {
     this.profile = profileDefinition
 
     await demandGitHubToken().catch((error) => {
-      this.log.error(error.message)
-      process.exit(1)
-    })
-
-    await demandNpmToken().catch((error) => {
       this.log.error(error.message)
       process.exit(1)
     })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -11,12 +11,3 @@ export async function demandGitHubToken(): Promise<void> {
 
   await validateAccessToken(GITHUB_TOKEN)
 }
-
-export async function demandNpmToken(): Promise<void> {
-  const { NODE_AUTH_TOKEN, NPM_AUTH_TOKEN } = process.env
-
-  invariant(
-    NODE_AUTH_TOKEN || NPM_AUTH_TOKEN,
-    'Failed to publish the package: neither "NODE_AUTH_TOKEN" nor "NPM_AUTH_TOKEN" environment variables were provided.',
-  )
-}


### PR DESCRIPTION
Token-less releases via Trusted publishing is the way. They do not require you to provide an NPM token alongside your release command. You can still provide the token, given you've configured your NPM package to accept it. 